### PR TITLE
add "xkbmap" to common packages

### DIFF
--- a/settings/packages.common
+++ b/settings/packages.common
@@ -9,6 +9,7 @@ xf86-video-scfb
 xf86-video-vesa
 xauth
 xinit
+xkbmap
 xdg-user-dirs
 xdg-utils
 firefox


### PR DESCRIPTION
Include "xkbamp" package in packages.common to be able to set the keyboard layout in the live environment already without having to manually install xkbmap