### PR TITLE
Fix path and use /dev/daX

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cdrecord /dev/usr/local/furybsd/iso/FuryBSD-12.1-XFCE.iso
 
 Write the XFCE image to usb stick:
 ```
-sudo dd if=/dev/usr/local/furybsd/iso/FuryBSD-12.1-XFCE.iso of=/dev/da0 bs=4m status=progress
+sudo dd if=/usr/local/furybsd/iso/FuryBSD-12.1-XFCE.iso of=/dev/daX bs=4m status=progress
 ```
 
 ## Credentials for live media


### PR DESCRIPTION
...to prevent from users mindlessly copying and pasting the command shoothing themselves into the foot