### PR TITLE
KDE

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,7 @@ task:
       DESKTOP: 'lumina'
       DESKTOP: 'xfce'
       DESKTOP: 'mate'
+      DESKTOP: 'kde'
 
   env:
     matrix:

--- a/build.sh
+++ b/build.sh
@@ -249,10 +249,10 @@ image()
 
 cleanup()
 {
-#  if [ ! -z "$CI" ] ; then
-#    # On CI systems there is no reason to clean up which takes time
-#    return
-#  fi
+if [ ! -z "${CI}" ] ; then
+  # On CI systems there is no reason to clean up which takes time
+  return
+fi
   if [ -d "${livecd}" ] ; then
     # chflags -R noschg ${uzip} ${cdroot} >/dev/null 2>/dev/null
     rm -rf ${uzip} ${cdroot} ${ports} >/dev/null 2>/dev/null

--- a/settings/packages.kde
+++ b/settings/packages.kde
@@ -1,8 +1,7 @@
-kde-baseapps
-plasma5-plasma
+# kde-baseapps # too many dependencies
 sddm
-firefox
-kf5-breeze-icons
-zenity
-sysctlview
-# pc-networkmanager # missing for i386?
+plasma5-plasma-desktop
+konsole
+dolphin
+falkon
+pc-networkmanager # !i386


### PR DESCRIPTION
* Reduce footprint of KDE image
* Build KDE image on Cirrus CI
* Speed up Cirrus CI builds by not cleaning up on CI

Reference:
https://github.com/furybsd/furybsd-livecd/issues/180