### PR TITLE
Portable wifi tool

### DIFF
--- a/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
+++ b/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
@@ -1,4 +1,7 @@
-#!/usr/local/bin/bash
+#!/bin/sh
+#
+# Configure wifi via dialogs
+#
 
 # Only run as superuser
 if [ "$(id -u)" != "0" ]; then

--- a/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
+++ b/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
@@ -6,6 +6,10 @@
 # in which case it will behave as if you are root and invent
 # some wifi devices for you.
 #
+
+### COMMAND-LINE ARGUMENTS
+#
+#
 if [ "x$1" = "x-d" ] ; then
   # In debug-mode, 
   #   - pretend we're root
@@ -25,6 +29,25 @@ else
   }
 fi
 
+### RUN-TIME DEPENDENCIES
+#
+#
+if test -x /usr/local/bin/zenity ; then
+  warning() {
+    /usr/local/bin/zenity --warning --no-wrap --text="$1"
+  }
+elif test -x /usr/local/bin/kdialog ; then
+  warning() {
+    /usr/local/bin/kdialog --title "Wifi-Tool Error" --error "$1"
+  }
+else
+  echo "No suitable GUI found" 1>&2
+  exit 1
+fi
+
+### SCRIPT PROPER
+#
+#
 # Only run as superuser
 if is_user ; then
   echo "This script must be run as root" 1>&2
@@ -39,7 +62,7 @@ rm /tmp/wlan-selection 2>/dev/null || true
 
 wnic=$(get_wireless)
 if [ "$?" -eq 0 ] && [ -z "${wnic}" ] ; then
-  zenity --warning --no-wrap --text="No wlan devices found"
+  warning "No wlan devices found"
   exit 0
 fi
 

--- a/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
+++ b/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
@@ -31,14 +31,32 @@ fi
 
 ### RUN-TIME DEPENDENCIES
 #
+# Based on the available tooling, defines the following functions:
+#   - warning <text>
+#     Displays the <text> as a warning, no output, no return value
+#   - ask_wifi_list <filename>
+#     Displays the interfaces from <filename> (one per line), pick one,
+#     outputs the item that was selected, no return value
 #
 if test -x /usr/local/bin/zenity ; then
   warning() {
     /usr/local/bin/zenity --warning --no-wrap --text="$1"
   }
+  ask_wifi_list() {
+    cat "$1" | zenity --list --width=640 --height=480 \
+      --title="FuryBSD Wifi Tool" \
+      --text="Detected wifi devices" \
+      --column="Module" 
+  }
 elif test -x /usr/local/bin/kdialog ; then
   warning() {
-    /usr/local/bin/kdialog --title "Wifi-Tool Error" --error "$1"
+    /usr/local/bin/kdialog --title "FuryBSD Wifi Tool" --error "$1"
+  }
+  ask_wifi_list() {
+    # KDialog uses <tag> <text> <state> triplets, so we need to
+    # expand the interface names to triples; assume no spaces in interfaces.
+    kdialog --title "FuryBSD Wifi Tool" --radiolist "Detected wifi devices" \
+      `awk '{ print $1" "$1" off"; }' "$1"`
   }
 else
   echo "No suitable GUI found" 1>&2
@@ -83,10 +101,7 @@ do
 done
 
 # Present list of detected wifi devices
-cat /tmp/wifi-devices-found.list | zenity --list --width=640 --height=480 \
---title="FuryBSD Wifi Tool" \
---text="Detected wifi devices" \
---column="Module" | tee /tmp/wifi-selection
+ask_wifi_list /tmp/wifi-devices-found.list | tee /tmp/wifi-selection
 
 # Now configure the wifi device in rc.conf based on user selection
 wnic=$(cat /tmp/wifi-selection)

--- a/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
+++ b/overlays/uzip/furybsd-wifi-tool/files/usr/local/bin/furybsd-wifi-tool
@@ -2,9 +2,31 @@
 #
 # Configure wifi via dialogs
 #
+# For debugging purposes, pass `-d` as parameter to the script,
+# in which case it will behave as if you are root and invent
+# some wifi devices for you.
+#
+if [ "x$1" = "x-d" ] ; then
+  # In debug-mode, 
+  #   - pretend we're root
+  #   - bogus wifi devices     
+  is_user() { 
+    false
+  }
+  get_wireless() {
+    echo "em0"
+  }
+else
+  is_user() { 
+    test "$(id -u)" != "0" 
+  }
+  get_wireless() {
+    sysctl -b net.wlan.devices
+  }
+fi
 
 # Only run as superuser
-if [ "$(id -u)" != "0" ]; then
+if is_user ; then
   echo "This script must be run as root" 1>&2
   exit 1
 fi
@@ -15,7 +37,7 @@ rm /tmp/wlan-selection 2>/dev/null || true
 
 # Check for no wifi devices and exit if none found
 
-wnic=$(sysctl -b net.wlan.devices)
+wnic=$(get_wireless)
 if [ "$?" -eq 0 ] && [ -z "${wnic}" ] ; then
   zenity --warning --no-wrap --text="No wlan devices found"
   exit 0
@@ -32,7 +54,7 @@ WLAN="wlan${WLANCOUNT}"
 
 
 # Check for any new wifi devices to setup
-for wnic in `sysctl -b net.wlan.devices 2>/dev/null`
+for wnic in `get_wireless 2>/dev/null`
 do
   echo ${wnic} >> /tmp/wifi-devices-found.list
 done


### PR DESCRIPTION
 - It's a shell script, not a bash script
 - Use either zenity or kdialog, whatever is installed: this would allow dropping zenity from the KDE image