### PR TITLE
Do not delete 'continuous' tag when uploading to GH Releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,7 @@ env:
 task:
   stateful: false
   timeout_in: 60m
+  only_if: $CIRRUS_TAG != 'continuous'
 
   env:
     matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,5 +43,5 @@ task:
     - ( cd "${CIRRUS_WORKING_DIR}" ; zsyncmake *.iso )
     - wget -c "https://raw.githubusercontent.com/probonopd/uploadtool/8142d461aba7b92a058116fe5ee75be438b75fa4/upload.sh"
     - export TRAVIS_REPO_SLUG="${CIRRUS_REPO_FULL_NAME}"
-    - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) wget https://github.com/tcnksm/ghr/files/5247714/ghr.zip ; unzip ghr.zip ; ./ghr -replace continuous "${CIRRUS_WORKING_DIR}"/*.iso* ; esac
+    - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) wget https://github.com/tcnksm/ghr/files/5247714/ghr.zip ; unzip ghr.zip ; ./ghr -replace -t "${GITHUB_TOKEN}" -u "${CIRRUS_REPO_OWNER}" -r "${CIRRUS_REPO_NAME}" -c "${CIRRUS_CHANGE_IN_REPO}" continuous "${CIRRUS_WORKING_DIR}"/artifacts ; esac
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,9 +38,9 @@ task:
     
   test_script:
     - /bin/sh -x ./build.sh "${DESKTOP}" || true # FIXME: Why does this return an error even though the ISO succeeded?
-    - ls -lh "${CIRRUS_WORKING_DIR}"/*.iso*
     - df -h
-    - ( cd "${CIRRUS_WORKING_DIR}" ; zsyncmake *.iso )
+    - ( cd "${CIRRUS_WORKING_DIR}"/artifacts ; zsyncmake *.iso )
+    - ls -lh "${CIRRUS_WORKING_DIR}"/artifacts/
     - wget -c "https://raw.githubusercontent.com/probonopd/uploadtool/8142d461aba7b92a058116fe5ee75be438b75fa4/upload.sh"
     - export TRAVIS_REPO_SLUG="${CIRRUS_REPO_FULL_NAME}"
     - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) wget https://github.com/tcnksm/ghr/files/5247714/ghr.zip ; unzip ghr.zip ; ./ghr -replace -t "${GITHUB_TOKEN}" -u "${CIRRUS_REPO_OWNER}" -r "${CIRRUS_REPO_NAME}" -c "${CIRRUS_CHANGE_IN_REPO}" continuous "${CIRRUS_WORKING_DIR}"/artifacts ; esac

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,7 +42,6 @@ task:
     - df -h
     - ( cd "${CIRRUS_WORKING_DIR}" ; zsyncmake *.iso )
     - wget -c "https://raw.githubusercontent.com/probonopd/uploadtool/8142d461aba7b92a058116fe5ee75be438b75fa4/upload.sh"
-    - export TRAVIS_COMMIT="${CIRRUS_CHANGE_IN_REPO}"
     - export TRAVIS_REPO_SLUG="${CIRRUS_REPO_FULL_NAME}"
-    - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) bash upload.sh "${CIRRUS_WORKING_DIR}"/*.iso* ; esac # This tool needs bash; FIXME
+    - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) wget https://github.com/tcnksm/ghr/files/5247714/ghr.zip ; unzip ghr.zip ; ./ghr -replace continuous "${CIRRUS_WORKING_DIR}"/*.iso* ; esac
 

--- a/build.sh
+++ b/build.sh
@@ -250,6 +250,7 @@ image()
 cleanup()
 {
 if [ ! -z "${CI}" ] ; then
+  zpool destroy -f furybsd
   # On CI systems there is no reason to clean up which takes time
   return
 fi

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ iso="${livecd}/iso"
     # On Cirrus CI ${livecd} is in tmpfs for speed reasons
     # and tends to run out of space. Writing the final ISO
     # to non-tmpfs should be an acceptable compromise
-    iso="${CIRRUS_WORKING_DIR}"
+    iso="${CIRRUS_WORKING_DIR}/artifacts"
   fi
 uzip="${livecd}/uzip"
 cdroot="${livecd}/cdroot"


### PR DESCRIPTION
Deleting and re-creating the continuous tag when uploading to GH Releases causes Cirrus CI to cancel the running build, which kills the upload of the ISO.

Hence, we do not delete and re-create the continuous tag for now, just delete pre-existing attachements with the same name as those that are being uploaded.

Not nice, but I don't know a better way for now.