### PR TITLE
Remove freebsd-installer package when installed

### DIFF
--- a/overlays/uzip/freebsd-installer/files/usr/local/bin/furybsd-install
+++ b/overlays/uzip/freebsd-installer/files/usr/local/bin/furybsd-install
@@ -89,6 +89,7 @@ bsdinstall entropy
 
 # Cleanup LiveCD restore specific contents from destination pool
 chroot "${FSMNT}" pkg remove -y furybsd-live-settings
+chroot "${FSMNT}" pkg remove -y freebsd-installer
 # TODO: Move all of this to pkg scripts of the pkg manifests that have installed these things
 chroot "${FSMNT}" rm /etc/rc.conf.local
 chroot "${FSMNT}" pw userdel liveuser


### PR DESCRIPTION
The installer currently does nothing useful on an already-installed system. Hence, remove it at installation time.