### PR TITLE
slim_enable="YES" if slim is present

### DIFF
--- a/overlays/uzip/freebsd-installer/files/usr/local/bin/furybsd-install
+++ b/overlays/uzip/freebsd-installer/files/usr/local/bin/furybsd-install
@@ -182,6 +182,9 @@ fi
 if [ -f "/usr/local/bin/sddm" ] ; then
   chroot "${FSMNT}" sysrc sddm_enable="YES"
 fi
+if [ -f "/usr/local/bin/slim" ] ; then
+  chroot "${FSMNT}" sysrc slim_enable="YES"
+fi
 
 # Set the timezone on the system if it has been provided
 # by the graphical installer frontend


### PR DESCRIPTION
Set `slim_enable="YES"` if slim is present, as we do for the other display managers.

This is needed, e.g., for the GNUstep, fynedesk, and hello variants.